### PR TITLE
update edgegrid-client due to caret constraints for 0.y.z

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "akamai-open/netstorage",
     "description": "Akamai NetStorage",
     "require": {
-        "akamai-open/edgegrid-client": "^0.3.0",
+        "akamai-open/edgegrid-client": "^0.6.0",
         "league/flysystem": "^1.0",
         "twistor/flysystem-stream-wrapper": "^1.0"
     },


### PR DESCRIPTION
Due to caret constraints with 0.y.z version an update of the edgegrid client to version 0.6.4 isn't possible since it will break installation of the netstorage client. 

please see: 
https://blog.madewithlove.be/post/tilde-and-caret-constraints/
http://semver.org/#spec-item-4